### PR TITLE
Fix build on musl libc

### DIFF
--- a/jshon.c
+++ b/jshon.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <jansson.h>
 #include <errno.h>
+#include <sys/types.h>
 
 // MIT licensed, (c) 2011 Kyle Keen <keenerd@gmail.com>
 


### PR DESCRIPTION
Without this patch:
```
x86_64-pc-linux-musl-cc -std=c99 -Wall -pedantic -Wextra -Werror    -c -o jshon.o jshon.c
jshon.c:214:5: error: unknown type name 'uint'
     uint     lin;  // array iterator
     ^
jshon.c: In function 'MAPNEXT':
jshon.c:267:38: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
             if (map_safe_peek()->lin >= json_array_size(*(map_safe_peek()->stk)))
                                      ^
cc1: all warnings being treated as errors
<builtin>: recipe for target 'jshon.o' failed
make: *** [jshon.o] Error 1
```