### PR TITLE
Made the -0 (null-delimit) work on -k (print keys) too.

### DIFF
--- a/jshon.1
+++ b/jshon.1
@@ -143,7 +143,7 @@ With
 (in-place) file editing.  Requires a file to modify and so only works with \-F.  This is meant for making slight changes to a json file.  When used, normal output is suppressed and the bottom of the edit stack is written out.
 .Pp
 .It Cm -0
-(null delimiters)  Changes the delimiter of \-u from a newline to a null.  This option only affects \-u because that is the only time a newline may legitimately appear in the output.
+(null delimiters)  Changes the delimiter of \-u and \-k from a newline to a null.  This option only affects \-u and \-k because that is the only time a newline may legitimately appear in the output.
 .Pp
 .It Cm --version
 Returns a YYYYMMDD timestamp and exits.

--- a/jshon.c
+++ b/jshon.c
@@ -639,7 +639,7 @@ int compare_strcmp(const void *a, const void *b)
     return strcmp(sa, sb);
 }
 
-void keys(json_t* json)
+void keys(json_t* json, char delim)
 // shoddy, prints directly
 {
     void* iter;
@@ -663,7 +663,7 @@ void keys(json_t* json)
         {qsort(keys, n, sizeof(char*), compare_strcmp);}
 
     for (i = 0; i < n; ++i)
-        {printf("%s\n", keys[i]);}
+        {printf("%s%c", keys[i], delim);}
 
     free(keys);
 }
@@ -997,7 +997,7 @@ int main (int argc, char *argv[])
                     output = 0;
                     break;
                 case 'k':  // keys
-                    keys(PEEK);
+                    keys(PEEK, delim);
                     output = 0;
                     break;
                 case 'u':  // unescape string


### PR DESCRIPTION
This functionality should be there for two reasons:
 1. The JSON spec allows \n in a key, so we have to deal with this
    possibility.
 2. There's no reason for it not to work. This is a small patch, and
    now users can have null-delimited keys if they want to. 