### PR TITLE
Add -E tag:name:value syntax to get a value from name/value pairs

### DIFF
--- a/jshon.1
+++ b/jshon.1
@@ -55,6 +55,19 @@ in the middle of them.
 .Pp
 \&  jshon \-e c -> {"d":4,"e":5}
 .Pp
+.It Cm -E nametag:namevalue:valuetag
+(Extract) returns json value from a name/value pair.  Only works on object.
+.br
+\&   Given:
+.br
+\&       [{ tagname: color, tagvalue: red },
+.br
+\&        { tagname: texture, tagvalue: squishy },
+.br
+\&        { tagname: height, tagvalue: 10ft }]
+.br
+\&   jshon -a -E tagname:height:tagvalue -> 10ft
+.Pp
 .It Cm -a
 (across) maps the remaining actions across the selected element.  Only works on objects and arrays.  Multiple
 .Nm \-a

--- a/jshon_zsh_completion
+++ b/jshon_zsh_completion
@@ -18,6 +18,7 @@ _jshon_opts_operations=(
 
 _jshon_opts_index=(
    -e'[returns json value at index]'
+   -E'[returns json value at tag:name:value]'
    -i'[insert item into array at index]'
    -d'[removes item in array or object]'
 )  


### PR DESCRIPTION
This is support name/value pairs like this:

    -E tag:value:value is for extracting  name/value pairs.  Given:
       [{ tagname: color, tagvalue: red },
        { tagname: texture, tagvalue: squishy },
        { tagname: height, tagvalue: 10ft }]
       jshon -a -E tagname:height:tagvalue -> 10ft

It's not beautiful, but I'm happy to work with you on the syntax.