### PR TITLE
add wrap (-w) option

### DIFF
--- a/jshon.1
+++ b/jshon.1
@@ -7,7 +7,7 @@
 .Nd JSON parser for the shell
 .Sh SYNOPSIS
 .Nm jshon
-\-[P|S|Q|V|C|I|0] [\-F path] \-[t|l|k|u|p|a|j] \-[s|n] value \-[e|i|d] index
+\-[P|S|Q|V|C|I|0] [\-F path] \-[t|l|k|u|p|a|j] \-[s|n] value \-[e|i|d|w] index
 .Sh DESCRIPTION
 .Nm
 parses, reads and creates JSON.  It is designed to be as usable as possible from within the shell and replaces fragile adhoc parsers made from grep/sed/awk as well as heavyweight one-line parsers made from perl/python.

--- a/jshon.c
+++ b/jshon.c
@@ -853,7 +853,7 @@ void debug_map()
 }
 
 int main (int argc, char *argv[])
-#define ALL_OPTIONS "PSQVCI0tlkupajF:e:s:n:d:i:"
+#define ALL_OPTIONS "PSQVCI0tlkupajF:e:s:n:d:i:w:"
 {
     char* content = "";
     char* arg1 = "";
@@ -918,10 +918,11 @@ int main (int argc, char *argv[])
             case 'd':
             case 'i':
             case 'a':
+            case 'w':
                 break;
             default:
                 if (!quiet)
-                    {fprintf(stderr, "Valid: -[P|S|Q|V|C|I|0] [-F path] -[t|l|k|u|p|a|j] -[s|n] value -[e|i|d] index\n");}
+                    {fprintf(stderr, "Valid: -[P|S|Q|V|C|I|0] [-F path] -[t|l|k|u|p|a|j] -[s|n] value -[e|i|d|w] index\n");}
                 if (crash)
                     {exit(2);}
                 break;
@@ -1052,6 +1053,12 @@ int main (int argc, char *argv[])
                     if (!empty)
                         {MAPNEXT();}
                     output = 0;
+                    break;
+                case 'w':  // wrap
+                    arg1 = (char*) strdup(optarg);
+                    json = POP;
+                    PUSH(update_native(json_object(), arg1, json));
+                    output = 1;
                     break;
                 case 'P':  // not manipulations
                 case 'S': 

--- a/jshon_zsh_completion
+++ b/jshon_zsh_completion
@@ -20,6 +20,7 @@ _jshon_opts_index=(
    -e'[returns json value at index]'
    -i'[insert item into array at index]'
    -d'[removes item in array or object]'
+   -w'[wraps item in named object]'
 )  
    
 # options for passing to _arguments: options common to all operations


### PR DESCRIPTION
This option will wrap the top of the stack in given key. Manipulation
example:

    $ cat sample.json
    {"a": 1, "b": 2}

    $ jshon -e a -w a2 -i a < sample.json
    {
     "a": {
      "a2": 1
     },
     "b": 2
    }