### PR TITLE
add rotate (-r) option

### DIFF
--- a/jshon.c
+++ b/jshon.c
@@ -853,7 +853,7 @@ void debug_map()
 }
 
 int main (int argc, char *argv[])
-#define ALL_OPTIONS "PSQVCI0tlkupajF:e:s:n:d:i:"
+#define ALL_OPTIONS "PSQVCI0tlkupajrF:e:s:n:d:i:"
 {
     char* content = "";
     char* arg1 = "";
@@ -918,10 +918,11 @@ int main (int argc, char *argv[])
             case 'd':
             case 'i':
             case 'a':
+            case 'r':
                 break;
             default:
                 if (!quiet)
-                    {fprintf(stderr, "Valid: -[P|S|Q|V|C|I|0] [-F path] -[t|l|k|u|p|a|j] -[s|n] value -[e|i|d] index\n");}
+                    {fprintf(stderr, "Valid: -[P|S|Q|V|C|I|0] [-F path] -[t|l|k|u|p|a|j|r] -[s|n] value -[e|i|d] index\n");}
                 if (crash)
                     {exit(2);}
                 break;
@@ -1051,6 +1052,13 @@ int main (int argc, char *argv[])
                     empty = map_safe_peek()->fin;
                     if (!empty)
                         {MAPNEXT();}
+                    output = 0;
+                    break;
+                case 'r':  // rotate
+                    jval = POP;
+                    json = POP;
+                    PUSH(jval);
+                    PUSH(json);
                     output = 0;
                     break;
                 case 'P':  // not manipulations


### PR DESCRIPTION
Rotates the two top items on the stack. This allows for some powerful manipulations.

- Wrap a json as a value (#52): `echo '{"a":1, "b":2}' | jshon -e a -n object -r -i a2 -i a` becomes `{"a": {"a2": 1}, "b":2}`
- Selecting some items by key (#55): `echo '{"a":1, "b":2, "c":3}' | jshon -e a -r -e b -r -p -n object -r -i b -r -i a` becomes `{"b":2, "a":1}`